### PR TITLE
Fix Bootstrap link comment typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
     <!-- Font Awesome Link -->
     <script src="https://kit.fontawesome.com/1632434743.js" crossorigin="anonymous"></script>
 
-    <!-- Bootstap Link -->
+    <!-- Bootstrap Link -->
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q"


### PR DESCRIPTION
## Summary
- Correct Bootstrap script tag comment typo in index.html

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aef973f9c832cac19ee2614a324c0