### PR TITLE
Fix difficulty selection comment and variable name

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,10 +1,10 @@
 /* jshint esversion: 11 */
 
-// -------------------------------------> Game difficutly selection
+// -------------------------------------> Game difficulty selection
 
-let saveDifficutly = Number(localStorage.getItem('gameDifficulty'));
-if (![1, 2, 3].includes(saveDifficutly)) saveDifficutly = 1;
-window.gameDifficulty = saveDifficutly;
+let saveDifficulty = Number(localStorage.getItem('gameDifficulty'));
+if (![1, 2, 3].includes(saveDifficulty)) saveDifficulty = 1;
+window.gameDifficulty = saveDifficulty;
 
 function updateSelectedBtn() {
   for (let i = 1; i <= 3; i++) {


### PR DESCRIPTION
## Summary
- fix spelling of difficulty selection comment
- rename saveDifficutly variable to saveDifficulty and update references

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint assets/js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689aef6eaf10832c9322322172a0064d